### PR TITLE
fix(interbank-service): read METRICS_PORT instead of INTERBANK_METRIC…

### DIFF
--- a/interbank-service/internal/config/config.go
+++ b/interbank-service/internal/config/config.go
@@ -51,7 +51,7 @@ func Load() *Config {
 		DBPassword:          getEnv("INTERBANK_DB_PASSWORD", "postgres"),
 		DBName:              getEnv("INTERBANK_DB_NAME", "interbankdb"),
 		GRPCAddr:            getEnv("INTERBANK_GRPC_ADDR", ":50062"),
-		MetricsPort:         getEnv("INTERBANK_METRICS_PORT", "9108"),
+		MetricsPort:         getEnv("METRICS_PORT", "9112"),
 		AccountGRPCAddr:     getEnv("ACCOUNT_GRPC_ADDR", "localhost:50055"),
 		StockGRPCAddr:       getEnv("STOCK_GRPC_ADDR", "localhost:50060"),
 		ClientGRPCAddr:      getEnv("CLIENT_GRPC_ADDR", "localhost:50054"),


### PR DESCRIPTION
…S_PORT

The service was defaulting to port 9108 because it read INTERBANK_METRICS_PORT which the Helm chart never sets. Every other service uses METRICS_PORT — aligning interbank-service fixes the Kubernetes readiness probe (chart sets METRICS_PORT=9112).