### PR TITLE
feat(logging): add PLG stack — structured JSON logging + Loki + Promtail

### DIFF
--- a/account-service/cmd/main.go
+++ b/account-service/cmd/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
+	"log/slog"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -23,6 +23,7 @@ import (
 	adminpb "github.com/exbanka/contract/adminpb"
 	clientpb "github.com/exbanka/contract/clientpb"
 	"github.com/exbanka/contract/cronreg"
+	"github.com/exbanka/contract/logger"
 	"github.com/exbanka/contract/metrics"
 	shared "github.com/exbanka/contract/shared"
 	"github.com/exbanka/contract/shared/grpcmw"
@@ -30,6 +31,7 @@ import (
 )
 
 func main() {
+	logger.Init("account-service")
 	cfg := config.Load()
 
 	service.SetBankCode(cfg.OwnBankCode)
@@ -260,7 +262,7 @@ func main() {
 		Signals: shared.DefaultShutdownSignals,
 		OnReady: func() {
 			markReady()
-			fmt.Printf("account service listening on %s\n", cfg.GRPCAddr)
+			slog.Info("account service listening", "addr", cfg.GRPCAddr)
 		},
 	}); err != nil {
 		log.Fatalf("grpc: %v", err)

--- a/api-gateway/cmd/main.go
+++ b/api-gateway/cmd/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -21,6 +21,7 @@ import (
 	gatewaykafka "github.com/exbanka/api-gateway/internal/kafka"
 	"github.com/exbanka/api-gateway/internal/middleware"
 	"github.com/exbanka/api-gateway/internal/router"
+	"github.com/exbanka/contract/logger"
 	"github.com/exbanka/contract/metrics"
 )
 
@@ -34,6 +35,7 @@ import (
 // @name                        Authorization
 // @description                 Enter "Bearer <token>"
 func main() {
+	logger.Init("api-gateway")
 	cfg := config.Load()
 
 	authClient, authConn, err := grpcclients.NewAuthClient(cfg.AuthGRPCAddr)
@@ -399,7 +401,7 @@ func main() {
 	// Start HTTP server in goroutine
 	markReady()
 	go func() {
-		fmt.Printf("API Gateway listening on %s\n", cfg.HTTPAddr)
+		slog.Info("API Gateway listening", "addr", cfg.HTTPAddr)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Fatalf("failed to start server: %v", err)
 		}

--- a/auth-service/cmd/main.go
+++ b/auth-service/cmd/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
+	"log/slog"
 	"time"
 
 	"google.golang.org/grpc"
@@ -21,6 +21,7 @@ import (
 	"github.com/exbanka/auth-service/internal/service"
 	authpb "github.com/exbanka/contract/authpb"
 	kafkamsg "github.com/exbanka/contract/kafka"
+	"github.com/exbanka/contract/logger"
 	"github.com/exbanka/contract/metrics"
 	shared "github.com/exbanka/contract/shared"
 	"github.com/exbanka/contract/shared/grpcmw"
@@ -28,6 +29,7 @@ import (
 )
 
 func main() {
+	logger.Init("auth-service")
 	cfg := config.Load()
 
 	db, err := gorm.Open(postgres.Open(cfg.DSN()), &gorm.Config{
@@ -173,7 +175,7 @@ func main() {
 		Signals: shared.DefaultShutdownSignals,
 		OnReady: func() {
 			markReady()
-			fmt.Printf("Auth service listening on %s\n", cfg.GRPCAddr)
+			slog.Info("Auth service listening", "addr", cfg.GRPCAddr)
 		},
 	}); err != nil {
 		log.Fatalf("grpc: %v", err)

--- a/card-service/cmd/main.go
+++ b/card-service/cmd/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
+	"log/slog"
 	"time"
 
 	"google.golang.org/grpc"
@@ -23,12 +23,14 @@ import (
 	pb "github.com/exbanka/contract/cardpb"
 	clientpb "github.com/exbanka/contract/clientpb"
 	"github.com/exbanka/contract/cronreg"
+	"github.com/exbanka/contract/logger"
 	"github.com/exbanka/contract/metrics"
 	shared "github.com/exbanka/contract/shared"
 	"github.com/exbanka/contract/shared/grpcmw"
 )
 
 func main() {
+	logger.Init("card-service")
 	cfg := config.Load()
 
 	db, err := gorm.Open(postgres.Open(cfg.DSN()), &gorm.Config{
@@ -133,7 +135,7 @@ func main() {
 		Signals: shared.DefaultShutdownSignals,
 		OnReady: func() {
 			markReady()
-			fmt.Printf("card service listening on %s\n", cfg.GRPCAddr)
+			slog.Info("card service listening", "addr", cfg.GRPCAddr)
 		},
 	}); err != nil {
 		log.Fatalf("grpc: %v", err)

--- a/client-service/cmd/main.go
+++ b/client-service/cmd/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
+	"log/slog"
 	"time"
 
 	"google.golang.org/grpc"
@@ -20,6 +20,7 @@ import (
 	"github.com/exbanka/client-service/internal/repository"
 	"github.com/exbanka/client-service/internal/service"
 	clientpb "github.com/exbanka/contract/clientpb"
+	"github.com/exbanka/contract/logger"
 	"github.com/exbanka/contract/metrics"
 	shared "github.com/exbanka/contract/shared"
 	"github.com/exbanka/contract/shared/grpcmw"
@@ -27,6 +28,7 @@ import (
 )
 
 func main() {
+	logger.Init("client-service")
 	cfg := config.Load()
 
 	db, err := gorm.Open(postgres.Open(cfg.DSN()), &gorm.Config{
@@ -131,7 +133,7 @@ func main() {
 		Signals: shared.DefaultShutdownSignals,
 		OnReady: func() {
 			markReady()
-			fmt.Printf("client service listening on %s\n", cfg.GRPCAddr)
+			slog.Info("client service listening", "addr", cfg.GRPCAddr)
 		},
 	}); err != nil {
 		log.Fatalf("grpc: %v", err)

--- a/contract/logger/logger.go
+++ b/contract/logger/logger.go
@@ -1,0 +1,23 @@
+// Package logger initialises the process-wide structured JSON logger.
+//
+// Call Init once at the top of main() before any other setup. After that,
+// every slog.Info/Warn/Error call emits a JSON line, and every log.Printf /
+// log.Println call is automatically routed through the same JSON handler
+// (Go 1.21+ slog.SetDefault behaviour).
+package logger
+
+import (
+	"log/slog"
+	"os"
+)
+
+// Init configures the global slog default to a JSON handler writing to stdout
+// and injects "service" into every log record. It also redirects the legacy
+// log package through the same handler so existing log.Printf calls emit JSON
+// without any further changes.
+func Init(service string) {
+	h := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})
+	slog.SetDefault(slog.New(h).With("service", service))
+}

--- a/contract/logger/logger_test.go
+++ b/contract/logger/logger_test.go
@@ -1,0 +1,34 @@
+package logger_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/exbanka/contract/logger"
+)
+
+func TestInit_SetsJSONHandler(t *testing.T) {
+	logger.Init("test-service")
+
+	var buf bytes.Buffer
+	h := slog.NewJSONHandler(&buf, nil)
+	slog.SetDefault(slog.New(h).With("service", "test-service"))
+
+	slog.Info("hello", "key", "value")
+
+	var record map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &record); err != nil {
+		t.Fatalf("log output is not valid JSON: %v\noutput: %s", err, buf.String())
+	}
+	if record["msg"] != "hello" {
+		t.Errorf("expected msg=hello, got %v", record["msg"])
+	}
+	if record["service"] != "test-service" {
+		t.Errorf("expected service=test-service, got %v", record["service"])
+	}
+	if record["key"] != "value" {
+		t.Errorf("expected key=value, got %v", record["key"])
+	}
+}

--- a/credit-service/cmd/main.go
+++ b/credit-service/cmd/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
+	"log/slog"
 	"time"
 
 	"google.golang.org/grpc"
@@ -16,6 +16,7 @@ import (
 	clientpb "github.com/exbanka/contract/clientpb"
 	pb "github.com/exbanka/contract/creditpb"
 	"github.com/exbanka/contract/cronreg"
+	"github.com/exbanka/contract/logger"
 	"github.com/exbanka/contract/metrics"
 	shared "github.com/exbanka/contract/shared"
 	"github.com/exbanka/contract/shared/grpcmw"
@@ -30,6 +31,7 @@ import (
 )
 
 func main() {
+	logger.Init("credit-service")
 	cfg := config.Load()
 
 	db, err := gorm.Open(postgres.Open(cfg.DSN()), &gorm.Config{
@@ -182,7 +184,7 @@ func main() {
 		Signals: shared.DefaultShutdownSignals,
 		OnReady: func() {
 			markReady()
-			fmt.Printf("credit service listening on %s\n", cfg.GRPCAddr)
+			slog.Info("credit service listening", "addr", cfg.GRPCAddr)
 		},
 	}); err != nil {
 		log.Fatalf("grpc: %v", err)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -273,6 +273,25 @@ services:
       - "3001:3000"
     depends_on:
       - prometheus
+      - loki
+
+  loki:
+    image: grafana/loki:3.0.0
+    ports:
+      - "3100:3100"
+    volumes:
+      - loki_data:/loki
+    command: -config.file=/etc/loki/local-config.yaml
+
+  promtail:
+    image: grafana/promtail:3.0.0
+    volumes:
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./promtail-config.docker.yml:/etc/promtail/config.yml:ro
+    command: -config.file=/etc/promtail/config.yml
+    depends_on:
+      - loki
 
   # ─── Services ─────────────────────────────────────────────────────────────
 
@@ -836,3 +855,4 @@ volumes:
   interbank-db-data:
   prometheus_data:
   grafana_data:
+  loki_data:

--- a/docs/superpowers/specs/2026-06-09-grafana-logging-design.md
+++ b/docs/superpowers/specs/2026-06-09-grafana-logging-design.md
@@ -1,0 +1,126 @@
+# Grafana Logging Stack (PLG) — Design Spec
+
+**Date:** 2026-06-09
+**Status:** Implemented
+
+---
+
+## Goal
+
+Aggregate structured logs from all EXBanka microservices into Grafana so developers can query, filter, and correlate log lines across services in both local dev (docker-compose) and production (AKS).
+
+---
+
+## Architecture
+
+```
+Go services (slog JSON → stdout)
+        │
+        ▼
+  [docker-compose]              [Kubernetes / AKS]
+  Promtail                      Promtail DaemonSet
+  (Docker socket)               (/var/log/pods on each node)
+        │                               │
+        └──────────────┬────────────────┘
+                       ▼
+                     Loki
+           (labels: service / namespace / level)
+                       │
+                       ▼
+                   Grafana
+            (Prometheus datasource unchanged;
+             Loki datasource added)
+```
+
+---
+
+## Components
+
+### 1. `contract/logger` — shared JSON logger
+
+**File:** `contract/logger/logger.go`
+
+`Init(service string)` sets `slog.SetDefault` to a `slog.NewJSONHandler(os.Stdout)` with a `"service"` attribute pre-populated. In Go 1.21+, `slog.SetDefault` also redirects the legacy `log` package through the same handler — so existing `log.Printf` calls throughout each service automatically emit JSON without any further changes.
+
+Called once per service as the very first statement in `cmd/main.go`.
+
+### 2. Per-service logger init
+
+Each of the 13 services calls `logger.Init("<service-name>")` before any other setup. `fmt.Printf` startup messages are replaced with `slog.Info` to ensure they are included in the JSON log stream.
+
+Services updated: api-gateway, auth-service, user-service, notification-service, client-service, account-service, card-service, transaction-service, credit-service, exchange-service, stock-service, verification-service, interbank-service.
+
+### 3. Loki — log storage
+
+- **docker-compose:** `grafana/loki:3.0.0`, default built-in config, data persisted in `loki_data` volume, port 3100.
+- **Kubernetes:** `k8s/logging/loki.yml` — Deployment + Service + ConfigMap in `monitoring` namespace. Single-replica, filesystem storage, 30-day retention.
+
+### 4. Promtail — log collector
+
+- **docker-compose:** `grafana/promtail:3.0.0`, reads container logs via Docker socket (`/var/run/docker.sock`), config in `promtail-config.docker.yml`. Pipeline stage parses JSON lines and promotes `level` to a Loki label.
+- **Kubernetes:** `k8s/logging/promtail.yml` — DaemonSet + ConfigMap + ServiceAccount + ClusterRole/Binding in `monitoring` namespace. Reads pod logs from `/var/log/pods` on each node. Relabels `app` pod label → `service` Loki label.
+
+### 5. Grafana datasource
+
+`grafana/provisioning/datasources/loki.yml` provisions the Loki datasource automatically on Grafana startup. `url: http://loki:3100` (docker-compose). For Kubernetes, configure `http://loki.monitoring.svc.cluster.local:3100` via UI or ConfigMap patch.
+
+### 6. prometheus.yml
+
+Added `interbank-service` scrape target on port 9112 (the correct metrics port after the `INTERBANK_METRICS_PORT` → `METRICS_PORT` fix).
+
+---
+
+## Log Format
+
+Every log line emitted by any service is a JSON object on a single line:
+
+```json
+{"time":"2026-06-09T00:21:39Z","level":"INFO","msg":"http_request","service":"api-gateway","request_id":"d8a272a3","method":"GET","path":"/api/v3/peer-banks","status":200,"latency_ms":42}
+```
+
+Fields common to all log lines:
+- `time` — RFC3339 timestamp
+- `level` — DEBUG / INFO / WARN / ERROR
+- `msg` — human-readable message
+- `service` — service name (set by `logger.Init`)
+
+Additional fields are passed as key-value pairs at each call site.
+
+---
+
+## Key LogQL Queries
+
+```logql
+# All errors across the cluster
+{namespace=~"project-exbanka-instance."} | json | level="ERROR"
+
+# Trace a single request end-to-end
+{namespace=~"project-exbanka-instance."} | json | request_id="<uuid>"
+
+# Peer-banks requests only
+{service="api-gateway"} | json | path="/api/v3/peer-banks"
+
+# Stock-service OOM events
+{service="stock-service"} | json | level="ERROR"
+```
+
+---
+
+## Deployment
+
+### docker-compose
+
+```bash
+docker compose up -d loki promtail
+# Grafana datasource is provisioned automatically on next restart
+docker compose restart grafana
+```
+
+### Kubernetes
+
+```bash
+kubectl create namespace monitoring --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -f k8s/logging/loki.yml
+kubectl apply -f k8s/logging/promtail.yml
+# See k8s/logging/README.md for Grafana datasource setup
+```

--- a/exchange-service/cmd/main.go
+++ b/exchange-service/cmd/main.go
@@ -10,6 +10,7 @@ import (
 	"gorm.io/gorm"
 
 	pb "github.com/exbanka/contract/exchangepb"
+	"github.com/exbanka/contract/logger"
 	"github.com/exbanka/contract/metrics"
 	shared "github.com/exbanka/contract/shared"
 	"github.com/exbanka/contract/shared/grpcmw"
@@ -24,6 +25,7 @@ import (
 )
 
 func main() {
+	logger.Init("exchange-service")
 	cfg := config.Load()
 
 	db, err := gorm.Open(postgres.Open(cfg.DSN()), &gorm.Config{

--- a/grafana/provisioning/datasources/loki.yml
+++ b/grafana/provisioning/datasources/loki.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: false
+    editable: true
+    jsonData:
+      maxLines: 1000

--- a/interbank-service/cmd/main.go
+++ b/interbank-service/cmd/main.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"time"
@@ -26,6 +27,7 @@ import (
 	adminpb "github.com/exbanka/contract/adminpb"
 	clientpb "github.com/exbanka/contract/clientpb"
 	"github.com/exbanka/contract/cronreg"
+	"github.com/exbanka/contract/logger"
 	"github.com/exbanka/contract/metrics"
 	shared "github.com/exbanka/contract/shared"
 	"github.com/exbanka/contract/shared/grpcmw"
@@ -41,6 +43,7 @@ import (
 )
 
 func main() {
+	logger.Init("interbank-service")
 	cfg := config.Load()
 	ctx := context.Background()
 
@@ -209,7 +212,7 @@ func main() {
 		Signals: shared.DefaultShutdownSignals,
 		OnReady: func() {
 			markReady()
-			fmt.Printf("interbank-service listening on %s (ops http :%s)\n", cfg.GRPCAddr, cfg.MetricsPort)
+			slog.Info("interbank-service listening", "addr", cfg.GRPCAddr, "metrics_port", cfg.MetricsPort)
 		},
 	}); err != nil {
 		log.Fatalf("interbank-service: grpc: %v", err)

--- a/k8s/logging/README.md
+++ b/k8s/logging/README.md
@@ -1,0 +1,69 @@
+# Logging Stack — Kubernetes Manifests
+
+Deploys **Loki** (log storage) and **Promtail** (log collector DaemonSet) into the `monitoring` namespace on the AKS cluster.
+
+## Prerequisites
+
+```bash
+# Create the monitoring namespace if it doesn't exist yet
+kubectl create namespace monitoring --dry-run=client -o yaml | kubectl apply -f -
+```
+
+## Deploy
+
+```bash
+# Deploy Loki
+kubectl apply -f k8s/logging/loki.yml
+
+# Deploy Promtail (RBAC + DaemonSet)
+kubectl apply -f k8s/logging/promtail.yml
+```
+
+## Verify
+
+```bash
+# Loki should become ready within ~30s
+kubectl rollout status deployment/loki -n monitoring
+
+# One Promtail pod per node
+kubectl get pods -n monitoring -l app=promtail
+
+# Tail Promtail logs to confirm it is shipping to Loki
+kubectl logs -n monitoring -l app=promtail --tail=20
+```
+
+## Add Loki datasource to Grafana
+
+If Grafana is deployed in the cluster, patch its provisioning ConfigMap to add:
+
+```yaml
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki.monitoring.svc.cluster.local:3100
+    isDefault: false
+    editable: true
+    jsonData:
+      maxLines: 1000
+```
+
+Or use Grafana's UI: **Configuration → Data Sources → Add → Loki → URL: `http://loki.monitoring.svc.cluster.local:3100`**.
+
+## Query logs in Grafana
+
+Open **Explore**, select the **Loki** datasource, and use LogQL:
+
+```logql
+# All logs from a specific service across both instances
+{service="api-gateway"}
+
+# Error logs across the whole cluster
+{namespace=~"project-exbanka-instance."} | json | level="ERROR"
+
+# Peer-banks request trace
+{service="api-gateway"} | json | path="/api/v3/peer-banks"
+
+# Logs for a specific request ID
+{namespace=~"project-exbanka-instance."} | json | request_id="<uuid>"
+```

--- a/k8s/logging/loki.yml
+++ b/k8s/logging/loki.yml
@@ -1,0 +1,121 @@
+---
+# Loki ConfigMap — minimal single-process config for AKS.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-config
+  namespace: monitoring
+data:
+  loki.yaml: |
+    auth_enabled: false
+
+    server:
+      http_listen_port: 3100
+      grpc_listen_port: 9096
+
+    common:
+      instance_addr: 127.0.0.1
+      path_prefix: /loki
+      storage:
+        filesystem:
+          chunks_directory: /loki/chunks
+          rules_directory: /loki/rules
+      replication_factor: 1
+      ring:
+        kvstore:
+          store: inmemory
+
+    schema_config:
+      configs:
+        - from: 2024-01-01
+          store: tsdb
+          object_store: filesystem
+          schema: v13
+          index:
+            prefix: index_
+            period: 24h
+
+    ruler:
+      alertmanager_url: http://localhost:9093
+
+    limits_config:
+      retention_period: 720h   # 30 days
+
+    compactor:
+      retention_enabled: true
+      delete_request_store: filesystem
+---
+# Loki Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loki
+  namespace: monitoring
+  labels:
+    app: loki
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: loki
+  template:
+    metadata:
+      labels:
+        app: loki
+    spec:
+      containers:
+        - name: loki
+          image: grafana/loki:3.0.0
+          args:
+            - -config.file=/etc/loki/loki.yaml
+          ports:
+            - name: http
+              containerPort: 3100
+            - name: grpc
+              containerPort: 9096
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki
+            - name: data
+              mountPath: /loki
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+      volumes:
+        - name: config
+          configMap:
+            name: loki-config
+        - name: data
+          emptyDir: {}
+---
+# Loki Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki
+  namespace: monitoring
+  labels:
+    app: loki
+spec:
+  selector:
+    app: loki
+  ports:
+    - name: http
+      port: 3100
+      targetPort: http

--- a/k8s/logging/promtail.yml
+++ b/k8s/logging/promtail.yml
@@ -1,0 +1,154 @@
+---
+# RBAC — Promtail needs to list/watch Pods and Namespaces for service-discovery
+# labels (instance name, pod name, namespace, container name).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: promtail
+  namespace: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: promtail
+rules:
+  - apiGroups: [""]
+    resources: [nodes, nodes/proxy, services, endpoints, pods]
+    verbs: [get, watch, list]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: promtail
+subjects:
+  - kind: ServiceAccount
+    name: promtail
+    namespace: monitoring
+roleRef:
+  kind: ClusterRole
+  name: promtail
+  apiGroup: rbac.authorization.k8s.io
+---
+# Promtail ConfigMap
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: promtail-config
+  namespace: monitoring
+data:
+  promtail.yaml: |
+    server:
+      http_listen_port: 9080
+      grpc_listen_port: 0
+
+    positions:
+      filename: /tmp/positions.yaml
+
+    clients:
+      - url: http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push
+
+    scrape_configs:
+      - job_name: kubernetes-pods
+        kubernetes_sd_configs:
+          - role: pod
+        pipeline_stages:
+          # Parse lines that are valid JSON (slog output). Non-JSON lines
+          # (pre-init fatals) pass through with only their raw log label.
+          - json:
+              expressions:
+                level: level
+                msg: msg
+          # Promote "level" to a Loki index label for fast filtering.
+          - labels:
+              level:
+        relabel_configs:
+          # Only scrape pods that have a running container.
+          - source_labels: [__meta_kubernetes_pod_container_name]
+            action: keep
+            regex: .+
+          # Derive the Loki "service" label from the app label on the pod.
+          - source_labels: [__meta_kubernetes_pod_label_app]
+            target_label: service
+          # Standard Kubernetes labels for log correlation.
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            target_label: pod
+          - source_labels: [__meta_kubernetes_pod_container_name]
+            target_label: container
+          # Use the node filesystem path to the pod log file.
+          - source_labels: [__meta_kubernetes_pod_uid, __meta_kubernetes_pod_container_name]
+            target_label: __path__
+            separator: /
+            replacement: /var/log/pods/*$1/*.log
+---
+# Promtail DaemonSet — one pod per node, mounts host log paths read-only.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: promtail
+  namespace: monitoring
+  labels:
+    app: promtail
+spec:
+  selector:
+    matchLabels:
+      app: promtail
+  template:
+    metadata:
+      labels:
+        app: promtail
+    spec:
+      serviceAccountName: promtail
+      tolerations:
+        # Run on system nodes too so no pod logs are missed.
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: promtail
+          image: grafana/promtail:3.0.0
+          args:
+            - -config.file=/etc/promtail/promtail.yaml
+          ports:
+            - name: http
+              containerPort: 9080
+          volumeMounts:
+            - name: config
+              mountPath: /etc/promtail
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsGroup: 0
+            runAsUser: 0
+      volumes:
+        - name: config
+          configMap:
+            name: promtail-config
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers

--- a/notification-service/cmd/main.go
+++ b/notification-service/cmd/main.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
+	"log/slog"
 	"time"
 
 	adminpb "github.com/exbanka/contract/adminpb"
 	"github.com/exbanka/contract/cronreg"
 	kafkamsg "github.com/exbanka/contract/kafka"
+	"github.com/exbanka/contract/logger"
 	"github.com/exbanka/contract/metrics"
 	notifpb "github.com/exbanka/contract/notificationpb"
 	shared "github.com/exbanka/contract/shared"
@@ -28,6 +29,7 @@ import (
 )
 
 func main() {
+	logger.Init("notification-service")
 	cfg := config.Load()
 
 	// Database
@@ -158,7 +160,7 @@ func main() {
 		Signals: shared.DefaultShutdownSignals,
 		OnReady: func() {
 			markReady()
-			fmt.Printf("Notification service listening on %s\n", cfg.GRPCAddr)
+			slog.Info("Notification service listening", "addr", cfg.GRPCAddr)
 		},
 	}); err != nil {
 		log.Fatalf("grpc: %v", err)

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -50,3 +50,7 @@ scrape_configs:
   - job_name: "verification-service"
     static_configs:
       - targets: ["verification-service:9111"]
+
+  - job_name: "interbank-service"
+    static_configs:
+      - targets: ["interbank-service:9112"]

--- a/promtail-config.docker.yml
+++ b/promtail-config.docker.yml
@@ -1,0 +1,37 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      # Strip the leading slash from the container name to get a clean service label.
+      - source_labels: [__meta_docker_container_name]
+        regex: '/(.+)'
+        target_label: service
+      # Preserve stdout vs stderr as a stream label.
+      - source_labels: [__meta_docker_container_log_stream]
+        target_label: stream
+      # Add the compose project name as a label for multi-project disambiguation.
+      - source_labels: [__meta_docker_container_label_com_docker_compose_project]
+        target_label: compose_project
+    pipeline_stages:
+      # Attempt to parse each line as JSON. Lines that are not JSON (e.g.
+      # pre-init log.Fatalf output) are kept as-is with only the raw log label.
+      - json:
+          expressions:
+            level: level
+            msg: msg
+            time: time
+      # Promote the parsed "level" field to a Loki label for fast filtering.
+      - labels:
+          level:

--- a/stock-service/cmd/main.go
+++ b/stock-service/cmd/main.go
@@ -19,6 +19,7 @@ import (
 	adminpb "github.com/exbanka/contract/adminpb"
 	clientpb "github.com/exbanka/contract/clientpb"
 	"github.com/exbanka/contract/cronreg"
+	"github.com/exbanka/contract/logger"
 	exchangepb "github.com/exbanka/contract/exchangepb"
 	"github.com/exbanka/contract/influx"
 	"github.com/exbanka/contract/metrics"
@@ -45,6 +46,7 @@ import (
 )
 
 func main() {
+	logger.Init("stock-service")
 	// Defence in depth: a binary built with saga fault injection (-tags
 	// sagafaults) must never run as a real service. The build tag already
 	// keeps the fault code out of production binaries; this refuses to even

--- a/transaction-service/cmd/main.go
+++ b/transaction-service/cmd/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
+	"log/slog"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -15,6 +15,7 @@ import (
 	accountpb "github.com/exbanka/contract/accountpb"
 	adminpb "github.com/exbanka/contract/adminpb"
 	"github.com/exbanka/contract/cronreg"
+	"github.com/exbanka/contract/logger"
 	exchangepb "github.com/exbanka/contract/exchangepb"
 	"github.com/exbanka/contract/metrics"
 	shared "github.com/exbanka/contract/shared"
@@ -30,6 +31,7 @@ import (
 )
 
 func main() {
+	logger.Init("transaction-service")
 	cfg := config.Load()
 
 	db, err := gorm.Open(postgres.Open(cfg.DSN()), &gorm.Config{
@@ -217,7 +219,7 @@ func main() {
 		Signals: shared.DefaultShutdownSignals,
 		OnReady: func() {
 			markReady()
-			fmt.Printf("transaction service listening on %s\n", cfg.GRPCAddr)
+			slog.Info("transaction service listening", "addr", cfg.GRPCAddr)
 		},
 	}); err != nil {
 		log.Fatalf("grpc: %v", err)

--- a/user-service/cmd/main.go
+++ b/user-service/cmd/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
+	"log/slog"
 	"time"
 
 	"google.golang.org/grpc"
@@ -12,6 +12,7 @@ import (
 
 	adminpb "github.com/exbanka/contract/adminpb"
 	"github.com/exbanka/contract/cronreg"
+	"github.com/exbanka/contract/logger"
 	"github.com/exbanka/contract/metrics"
 	shared "github.com/exbanka/contract/shared"
 	"github.com/exbanka/contract/shared/grpcmw"
@@ -26,6 +27,7 @@ import (
 )
 
 func main() {
+	logger.Init("user-service")
 	cfg := config.Load()
 
 	db, err := gorm.Open(postgres.Open(cfg.DSN()), &gorm.Config{
@@ -194,7 +196,7 @@ func main() {
 		Signals: shared.DefaultShutdownSignals,
 		OnReady: func() {
 			markReady()
-			fmt.Printf("user service listening on %s\n", cfg.GRPCAddr)
+			slog.Info("user service listening", "addr", cfg.GRPCAddr)
 		},
 	}); err != nil {
 		log.Fatalf("grpc: %v", err)

--- a/verification-service/cmd/main.go
+++ b/verification-service/cmd/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/exbanka/contract/logger"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"gorm.io/driver/postgres"
@@ -25,6 +26,7 @@ import (
 )
 
 func main() {
+	logger.Init("verification-service")
 	cfg := config.Load()
 
 	// 1. Connect to PostgreSQL


### PR DESCRIPTION
- contract/logger: new shared package; Init(service) sets slog JSON handler as the process default. Go 1.21+ slog.SetDefault also redirects the legacy log package, so all existing log.Printf calls emit JSON with no further changes needed.

- All 13 service cmd/main.go: call logger.Init("<service>") as the first statement in main(); replace fmt.Printf startup messages with slog.Info.

- prometheus.yml: add interbank-service scrape target on port 9112.

- grafana/provisioning/datasources/loki.yml: provision Loki datasource automatically on Grafana startup (docker-compose).

- docker-compose.yml: add loki (grafana/loki:3.0.0) and promtail (grafana/promtail:3.0.0) services; add loki_data volume.

- promtail-config.docker.yml: Docker socket discovery config; pipeline stage parses JSON lines and promotes `level` to a Loki label.

- k8s/logging/loki.yml: Loki Deployment + Service + ConfigMap for AKS (monitoring namespace, filesystem storage, 30-day retention).

- k8s/logging/promtail.yml: Promtail DaemonSet + RBAC for AKS; reads /var/log/pods on each node; relabels pod `app` label → Loki `service`.

- interbank-service/internal/config/config.go: read METRICS_PORT (not INTERBANK_METRICS_PORT) to match the Helm chart and all other services.